### PR TITLE
Fix de manejo de audio en Sonif1D

### DIFF
--- a/sonounoweb/sonif1D/templates/sonif1D/base.html
+++ b/sonounoweb/sonif1D/templates/sonif1D/base.html
@@ -229,15 +229,16 @@
                     renderGrafico(convertirData(dataJsonDesdeStorage));
                 }
             }
-    
-            // Manejo del audio
+    // Manejo del audio
             if (audioBase64) {
-                localStorage.setItem('audio_base64', audioBase64);
+                // GUARDAMOS EN MEMORIA RAM (esquivando el límite de 5MB del LocalStorage)
+                window.audioDataActual = audioBase64; 
                 const audioSource = audioPlayer.querySelector('source');
                 audioSource.src = "data:audio/wav;base64," + audioBase64;
                 audioPlayer.load();
             } else {
-                const audioBase64DesdeStorage = localStorage.getItem('audio_base64');
+                // LEEMOS DESDE LA MEMORIA RAM
+                const audioBase64DesdeStorage = window.audioDataActual;
                 if (audioBase64DesdeStorage) {
                     const audioSource = audioPlayer.querySelector('source');
                     audioSource.src = "data:audio/wav;base64," + audioBase64DesdeStorage;

--- a/sonounoweb/sonif1D/templates/sonif1D/navbar.html
+++ b/sonounoweb/sonif1D/templates/sonif1D/navbar.html
@@ -142,19 +142,20 @@
         });
     
         document.getElementById('downloadAudio').addEventListener('click', function(event) {
-            event.preventDefault();
-            // Obtener la cadena base64 del audio desde localStorage
-            var audioBase64 = localStorage.getItem('audio_base64');
-            if (audioBase64) {
-                // Crear un enlace de descarga
-                var link = document.createElement('a'); // Crear un enlace de descarga
-                link.href = 'data:audio/wav;base64,' + audioBase64;
-                link.download = 'audio.wav';
-                link.click();
-            } else {
-                alert('No se encontró un audio disponible.');
-            }
-        });
+    event.preventDefault();
+    // LEER EL AUDIO DESDE LA VARIABLE GLOBAL EN LA MEMORIA RAM
+    var audioBase64 = window.audioDataActual; 
+    
+    if (audioBase64) {
+        // Crear un enlace de descarga
+        var link = document.createElement('a'); 
+        link.href = 'data:audio/wav;base64,' + audioBase64;
+        link.download = 'audio.wav';
+        link.click();
+    } else {
+        alert('No se encontró un audio disponible.');
+    }
+});
         
         document.getElementById('downloadMarkers').addEventListener('click', function(event) {
             event.preventDefault();

--- a/sonounoweb/sonif1D/views.py
+++ b/sonounoweb/sonif1D/views.py
@@ -177,7 +177,7 @@ def cargar_archivo(ruta_archivo):
         return None
 
 # Función para reducir la cantidad de puntos en los datos
-def reducir_puntos(data, max_points=300):
+def reducir_puntos(data, max_points=3000):
     """
     Reduce la cantidad de puntos de datos manteniendo la forma general de la señal.
     Si los datos tienen más puntos que max_points, hace un submuestreo uniforme.
@@ -671,7 +671,9 @@ class simpleSound(object):
             data_x, data_y, Status = normalize(data_x, data_y)
 
             rep = self.reproductor
-            sound_buffer = b''
+            
+            # 1. CREAMOS UNA LISTA VACÍA (MUCHO MÁS RÁPIDO QUE NP.APPEND)
+            sound_chunks = []
 
             # Recorremos los datos para generar las ondas
             logger.info(f"Iniciando generación de {data_x.size} muestras de audio...")
@@ -683,10 +685,11 @@ class simpleSound(object):
                 # Generamos la onda de la frecuencia calculada
                 f = self.env * rep.volume * 2**15 * rep.generate_waveform(freq, delta_t=1)
 
-                if x == init:
-                    sound_to_save = f.astype('int16')
-                else:
-                    sound_to_save = np.append(sound_to_save, f.astype('int16'))
+                # 2. AGREGAMOS EL FRAGMENTO A LA LISTA
+                sound_chunks.append(f.astype('int16'))
+
+            # 3. UNIMOS TODO DE UNA SOLA VEZ AL FINAL CON NUMPY
+            sound_to_save = np.concatenate(sound_chunks)
 
             logger.info(f"Generación de ondas completada. Total de muestras de audio: {sound_to_save.size}")
 


### PR DESCRIPTION
Se cambió la función de manejo de audio en el front (Base.html)para guardarlo en memoria RAM, evitando el límite de 5MB que tiene LocalStorage, esto permite subir archivos de audio de mayor tamaño. Además se modifica la función de reducir puntos en los datos, y se crea una lista vacía para el guardado del audio en la función para generar el sonido en formato WAV en views.py. En navbar.html se modifica la función para leer el archivo de audio desde la memoria RAM y crear el enlace de descarga del mismo